### PR TITLE
#11 응답 캐싱 통합 테스트 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 

--- a/src/main/java/io/wisoft/apigatewaycaching/filter/RequestGlobalFilter.java
+++ b/src/main/java/io/wisoft/apigatewaycaching/filter/RequestGlobalFilter.java
@@ -50,6 +50,7 @@ public class RequestGlobalFilter implements GlobalFilter {
       if (cache != null) {
         final byte[] cacheBytes = cache.getBytes(StandardCharsets.UTF_8);
         final DataBuffer cacheBuffer = exchange.getResponse().bufferFactory().wrap(cacheBytes);
+        exchange.getResponse().getHeaders().set(HttpHeaders.CONTENT_TYPE, "application/json");
         return exchange.getResponse().writeWith(Flux.just(cacheBuffer));
       }
     }

--- a/src/test/java/io/wisoft/apigatewaycaching/integration/ResponseCachingIntegrationTest.java
+++ b/src/test/java/io/wisoft/apigatewaycaching/integration/ResponseCachingIntegrationTest.java
@@ -1,0 +1,85 @@
+package io.wisoft.apigatewaycaching.integration;
+
+import io.wisoft.apigatewaycaching.cache.CacheRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+
+import java.time.Duration;
+import java.util.List;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+public class ResponseCachingIntegrationTest {
+
+  private static final String REQUEST_URL = "/sensing/data";
+
+  @Autowired
+  private WebTestClient client;
+
+  @Autowired
+  private CacheRepository cacheRepository;
+
+  @BeforeEach
+  public void setup() {
+    final ExchangeStrategies exchangeStrategies = ExchangeStrategies.builder()
+        .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(-1))
+        .build();
+
+    client = client.mutate()
+        .responseTimeout(Duration.ofSeconds(10))
+        .exchangeStrategies(exchangeStrategies)
+        .build();
+
+    cacheRepository.delete(REQUEST_URL);
+  }
+
+  @Test
+  @Timeout(value = 10, unit = SECONDS)
+  void successTest() {
+    final long startTimeBeforeCaching = System.currentTimeMillis();
+    request();
+    final long elapsedTimeBeforeCaching = System.currentTimeMillis() - startTimeBeforeCaching;
+
+    final long startTimeAfterCaching = System.currentTimeMillis();
+    request();
+    final long elapsedTimeAfterCaching = System.currentTimeMillis() - startTimeAfterCaching;
+
+    assertThat(elapsedTimeAfterCaching).isLessThan(elapsedTimeBeforeCaching);
+  }
+
+  private void request() {
+    this.client
+        .get()
+        .uri(REQUEST_URL)
+        .accept(APPLICATION_JSON)
+        .header("Gateway-Cache-Method", "query")
+        .header("Gateway-Cache-Control", "max-age=120")
+        .exchange()
+        .expectStatus().isOk()
+        .expectHeader().valueEquals("Content-Type", "application/json")
+        .expectBody(new ParameterizedTypeReference<List<TestData>>() {
+        })
+        .consumeWith(response -> {
+          final List<TestData> responseBody = response.getResponseBody();
+          assertThat(responseBody).isNotNull();
+          assertThat(responseBody.size()).isEqualTo(1_000_000);
+        });
+  }
+
+
+  private static class TestData {
+    int id;
+    double value;
+  }
+
+}


### PR DESCRIPTION
- build.gradle
  - WebFlux 의존 추가
- src/main/j/i/w/a/filter/RequestGlobalFilter.java
  - 응답 헤더에 Content-Type 추가
- src/test/j/i/w/a/integration/ResponseCachingIntegrationTest.java
  - 응답 캐싱 통합 테스트 구현

Resolves: #11
See also: None