### PR TITLE
#12 RequestGlobalFilter 리팩토링

### DIFF
--- a/src/main/java/io/wisoft/apigatewaycaching/filter/RequestGlobalFilter.java
+++ b/src/main/java/io/wisoft/apigatewaycaching/filter/RequestGlobalFilter.java
@@ -1,60 +1,24 @@
 package io.wisoft.apigatewaycaching.filter;
 
-import io.wisoft.apigatewaycaching.cache.CacheRepository;
+import io.wisoft.apigatewaycaching.filter.service.QueryCachingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
-import org.springframework.core.io.buffer.DataBuffer;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
-import java.nio.charset.StandardCharsets;
-import java.util.List;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class RequestGlobalFilter implements GlobalFilter {
 
-  private final CacheRepository cacheRepository;
+  private final QueryCachingService queryCachingService;
 
   @Override
   public Mono<Void> filter(final ServerWebExchange exchange, final GatewayFilterChain chain) {
-    final HttpHeaders headers = exchange.getRequest().getHeaders();
-
-    final List<String> gatewayCacheControls = headers.get("Gateway-Cache-Control");
-    final List<String> gatewayCacheMethods = headers.get("Gateway-Cache-Method");
-
-    if (gatewayCacheMethods == null || gatewayCacheControls == null) {
-      log.info("Uncached Request");
-      return chain.filter(exchange);
-    }
-
-    final String gatewayCacheControl = gatewayCacheControls.get(0);
-    final String gatewayCacheMethod = gatewayCacheMethods.get(0);
-
-    log.info("Cache Control -> {}", gatewayCacheControl);
-    log.info("Cache Method -> {}", gatewayCacheMethod);
-
-    if (gatewayCacheMethod.equals("query")) {
-      final String requestPath = exchange.getRequest().getPath().value();
-
-      log.info("Request path -> {}", requestPath);
-
-      final String cache = cacheRepository.find(requestPath);
-
-      if (cache != null) {
-        final byte[] cacheBytes = cache.getBytes(StandardCharsets.UTF_8);
-        final DataBuffer cacheBuffer = exchange.getResponse().bufferFactory().wrap(cacheBytes);
-        exchange.getResponse().getHeaders().set(HttpHeaders.CONTENT_TYPE, "application/json");
-        return exchange.getResponse().writeWith(Flux.just(cacheBuffer));
-      }
-    }
-
-    return chain.filter(exchange);
+    return queryCachingService.handle(exchange, chain);
   }
+
 }

--- a/src/main/java/io/wisoft/apigatewaycaching/filter/service/CacheHeaderValidator.java
+++ b/src/main/java/io/wisoft/apigatewaycaching/filter/service/CacheHeaderValidator.java
@@ -1,0 +1,19 @@
+package io.wisoft.apigatewaycaching.filter.service;
+
+import io.wisoft.apigatewaycaching.filter.service.vo.GatewayCacheControl;
+import io.wisoft.apigatewaycaching.filter.service.vo.GatewayCacheMethod;
+import org.springframework.http.HttpHeaders;
+
+import java.util.Optional;
+
+public class CacheHeaderValidator {
+
+  private static final String QUERY_METHOD = "query";
+
+  public static boolean isValid(final HttpHeaders headers) {
+    final Optional<GatewayCacheControl> control = GatewayCacheControl.create(headers);
+    final Optional<GatewayCacheMethod> method = GatewayCacheMethod.create(headers);
+    return method.isPresent() && control.isPresent() && method.get().getValue().equals(QUERY_METHOD);
+  }
+
+}

--- a/src/main/java/io/wisoft/apigatewaycaching/filter/service/QueryCachingService.java
+++ b/src/main/java/io/wisoft/apigatewaycaching/filter/service/QueryCachingService.java
@@ -1,0 +1,42 @@
+package io.wisoft.apigatewaycaching.filter.service;
+
+import io.wisoft.apigatewaycaching.cache.CacheRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.nio.charset.StandardCharsets;
+
+import static io.wisoft.apigatewaycaching.filter.service.CacheHeaderValidator.isValid;
+
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QueryCachingService {
+
+  private final CacheRepository cacheRepository;
+
+  public Mono<Void> handle(final ServerWebExchange exchange, final GatewayFilterChain chain) {
+    if (isValid(exchange.getRequest().getHeaders())) {
+      final String requestPath = exchange.getRequest().getPath().value();
+
+      final String cache = cacheRepository.find(requestPath);
+
+      if (cache != null) {
+        final byte[] cacheBytes = cache.getBytes(StandardCharsets.UTF_8);
+        final DataBuffer cacheBuffer = exchange.getResponse().bufferFactory().wrap(cacheBytes);
+        exchange.getResponse().getHeaders().set(HttpHeaders.CONTENT_TYPE, "application/json");
+        return exchange.getResponse().writeWith(Flux.just(cacheBuffer));
+      }
+    }
+    return chain.filter(exchange);
+  }
+
+}

--- a/src/main/java/io/wisoft/apigatewaycaching/filter/service/exception/CacheMethodCreationException.java
+++ b/src/main/java/io/wisoft/apigatewaycaching/filter/service/exception/CacheMethodCreationException.java
@@ -1,0 +1,5 @@
+package io.wisoft.apigatewaycaching.filter.service.exception;
+
+public class CacheMethodCreationException extends RuntimeException {
+
+}

--- a/src/main/java/io/wisoft/apigatewaycaching/filter/service/vo/GatewayCacheControl.java
+++ b/src/main/java/io/wisoft/apigatewaycaching/filter/service/vo/GatewayCacheControl.java
@@ -1,0 +1,38 @@
+package io.wisoft.apigatewaycaching.filter.service.vo;
+
+import org.springframework.http.HttpHeaders;
+
+import java.util.List;
+import java.util.Optional;
+
+public class GatewayCacheControl {
+
+  private static final String KEY = "Gateway-Cache-Control";
+
+  private final int value;
+
+  private GatewayCacheControl(final int value) {
+    this.value = value;
+  }
+
+  public int getValue() {
+    return value;
+  }
+
+  public static Optional<GatewayCacheControl> create(final HttpHeaders headers) {
+    final List<String> cacheControls = headers.get(KEY);
+    if (cacheControls == null || cacheControls.size() != 1) return Optional.empty();
+
+    final String cacheControl = cacheControls.get(0);
+    final String stringValue = cacheControl.replace("max-age=", "");
+
+    try {
+      final int intValue = Integer.parseInt(stringValue);
+      final GatewayCacheControl control = new GatewayCacheControl(intValue);
+      return Optional.of(control);
+    } catch (NumberFormatException exception) {
+      return Optional.empty();
+    }
+  }
+
+}

--- a/src/main/java/io/wisoft/apigatewaycaching/filter/service/vo/GatewayCacheMethod.java
+++ b/src/main/java/io/wisoft/apigatewaycaching/filter/service/vo/GatewayCacheMethod.java
@@ -1,0 +1,34 @@
+package io.wisoft.apigatewaycaching.filter.service.vo;
+
+import org.springframework.http.HttpHeaders;
+
+import java.util.List;
+import java.util.Optional;
+
+public class GatewayCacheMethod {
+
+  private static final String KEY = "Gateway-Cache-Method";
+  private final String value;
+
+  private GatewayCacheMethod(final String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public static Optional<GatewayCacheMethod> create(final HttpHeaders headers) {
+    final List<String> cacheMethods = headers.get(KEY);
+    if (cacheMethods == null || cacheMethods.size() != 1) return Optional.empty();
+
+    final String cacheMethod = cacheMethods.get(0);
+    if (!(cacheMethod.equals("query") || cacheMethod.equals("command"))) {
+      return Optional.empty();
+    }
+
+    final GatewayCacheMethod gatewayCacheMethod = new GatewayCacheMethod(cacheMethod);
+    return Optional.of(gatewayCacheMethod);
+  }
+
+}

--- a/src/test/java/io/wisoft/apigatewaycaching/filter/service/vo/GatewayCacheControlTest.java
+++ b/src/test/java/io/wisoft/apigatewaycaching/filter/service/vo/GatewayCacheControlTest.java
@@ -1,0 +1,37 @@
+package io.wisoft.apigatewaycaching.filter.service.vo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class GatewayCacheControlTest {
+
+  private static final String KEY = "Gateway-Cache-Control";
+
+  private HttpHeaders mockHeaders;
+
+  @BeforeEach
+  void setup() {
+    mockHeaders = mock(HttpHeaders.class);
+  }
+
+  @Test
+  void successCreateTest() {
+    final int expectedValue = 120;
+    given(mockHeaders.get(KEY)).willReturn(List.of("max-age=" + expectedValue));
+
+    final Optional<GatewayCacheControl> gatewayCacheControl = GatewayCacheControl.create(mockHeaders);
+
+    assertThat(gatewayCacheControl.isPresent()).isTrue();
+    assertThat(gatewayCacheControl.get().getValue()).isEqualTo(expectedValue);
+  }
+
+}

--- a/src/test/java/io/wisoft/apigatewaycaching/filter/service/vo/GatewayCacheMethodTest.java
+++ b/src/test/java/io/wisoft/apigatewaycaching/filter/service/vo/GatewayCacheMethodTest.java
@@ -1,0 +1,55 @@
+package io.wisoft.apigatewaycaching.filter.service.vo;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+
+class GatewayCacheMethodTest {
+
+  private static final String KEY = "Gateway-Cache-Method";
+
+  private HttpHeaders mockHeaders;
+
+  @BeforeEach
+  void setup() {
+    mockHeaders = mock(HttpHeaders.class);
+  }
+
+  @Test
+  void successCreateTest() {
+    final String expectedValue = "query";
+    given(mockHeaders.get(KEY)).willReturn(List.of(expectedValue));
+
+    final Optional<GatewayCacheMethod> gatewayCacheMethod = GatewayCacheMethod.create(mockHeaders);
+
+    assertThat(gatewayCacheMethod.isPresent()).isTrue();
+    assertThat(gatewayCacheMethod.get().getValue()).isEqualTo(expectedValue);
+  }
+
+  @Test
+  void failCreateWithInvalidKeyTest() {
+    given(mockHeaders.get(KEY)).willReturn(null);
+
+    final Optional<GatewayCacheMethod> gatewayCacheMethod = GatewayCacheMethod.create(mockHeaders);
+
+    assertThat(gatewayCacheMethod.isPresent()).isFalse();
+  }
+
+  @Test
+  void failCreateWithInvalidValueTest() {
+    given(mockHeaders.get(KEY)).willReturn(List.of("invalidValue"));
+
+    final Optional<GatewayCacheMethod> gatewayCacheMethod = GatewayCacheMethod.create(mockHeaders);
+
+    assertThat(gatewayCacheMethod.isPresent()).isFalse();
+  }
+
+}

--- a/src/test/java/io/wisoft/apigatewaycaching/integration/ResponseCachingIntegrationTest.java
+++ b/src/test/java/io/wisoft/apigatewaycaching/integration/ResponseCachingIntegrationTest.java
@@ -3,7 +3,6 @@ package io.wisoft.apigatewaycaching.integration;
 import io.wisoft.apigatewaycaching.cache.CacheRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.ParameterizedTypeReference;
@@ -13,7 +12,6 @@ import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import java.time.Duration;
 import java.util.List;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -36,7 +34,7 @@ public class ResponseCachingIntegrationTest {
         .build();
 
     client = client.mutate()
-        .responseTimeout(Duration.ofSeconds(10))
+        .responseTimeout(Duration.ofSeconds(20))
         .exchangeStrategies(exchangeStrategies)
         .build();
 
@@ -44,7 +42,6 @@ public class ResponseCachingIntegrationTest {
   }
 
   @Test
-  @Timeout(value = 10, unit = SECONDS)
   void successTest() {
     final long startTimeBeforeCaching = System.currentTimeMillis();
     request();


### PR DESCRIPTION
- s/main/j/i/w/a/filter/RequestGlobalFilter.java
  - Caching 처리를 위임하도록 코드 수정
- s/main/j/i/w/a/filter/s/CacheHeaderValidator.java
  - 요청 헤더에서 Cache 관련 헤더 검증 클래스 구현
- s/main/j/i/w/a/filter/s/QueryCachingService.java
  - Caching 처리 클래스 구현
- s/main/j/i/w/a/filter/s/exception/CacheMethodCreationException.java
  - 잘못된 헤더 값이 전달되었을 때 발생하는 예외 구현
- s/main/j/i/w/a/filter/s/vo/GatewayCacheControl.java
  - GatewayCacheControl 헤더 값 객체 구현
- s/main/j/i/w/a/filter/s/vo/GatewayCacheMethod.java
  - GatewayCacheMethod 헤더 값 객체 구현
- s/test/j/i/w/a/filter/s/vo/GatewayCacheControlTest.java
  - GatewayCacheControl 생성 성공 및 실패 테스트 구현
- s/test/j/i/w/a/filter/s/vo/GatewayCacheMethodTest.java
  - GatewayCacheMethod 생성 성공 및 실패 테스트 구현
- s/test/j/i/w/a/integration/ResponseCachingIntegrationTest.java
  - 통합 테스트에서 사용하지 않는 import 제거

Resolves: #12
See also: None